### PR TITLE
Feature of add a classic gather pool to the invitational one by voting

### DIFF
--- a/app/javascripts/components/gather.js
+++ b/app/javascripts/components/gather.js
@@ -347,6 +347,23 @@ const GatherActions = React.createClass({
 		}, 0);
 	},
 
+	voteAddClassicPool(e) {
+		e.preventDefault(e);
+		this.props.socket.emit("gather:vote", {
+			type: 'invitational',
+			addClassicPool: true
+		})
+	},
+
+	addClassicPoolVotes() {
+		let gather = this.props.gather;
+		if (!gather) return 0;
+		return gather.gatherers.reduce((acc, gatherer) => {
+			if (gatherer.addClassicPoolVote) acc++;
+			return acc;
+		}, 0);
+	},
+
 	render() {
 		let regatherButton;
 		const user = this.props.user;
@@ -368,6 +385,22 @@ const GatherActions = React.createClass({
 			}
 		}
 
+		let addClassicPoolButton = null;
+		const addClassicPoolThreshold = this.props.gather.addClassicPoolThreshold;
+		if (thisGatherer && addClassicPoolThreshold && gather.type === 'invitational') {
+			let addClassicPoolVotes = this.addClassicPoolVotes();
+			let addClassicPoolButtonText = 
+			  thisGatherer.addClassicPoolVote 
+			    ? `Unvote for add classic pool (${addClassicPoolVotes}/${addClassicPoolThreshold})` 
+			    : `Vote for add classic pool (${addClassicPoolVotes}/${addClassicPoolThreshold})`;
+			addClassicPoolButton = <button 
+									 className='btn btn-danger'
+									 onClick={this.voteAddClassicPool}
+									 disabled={this.props.gather.state !== 'gathering' ? true : false}>
+									  {addClassicPoolButtonText}
+								   </button>
+		}
+
 		return (
 			<div>
 				<div className="text-right">
@@ -379,6 +412,7 @@ const GatherActions = React.createClass({
 						<li>
 							{regatherButton}
 						</li>
+						{addClassicPoolButton ? <li>{addClassicPoolButton}</li> : ''}
 					</ul>
 				</div>
 			</div>

--- a/app/javascripts/components/main.js
+++ b/app/javascripts/components/main.js
@@ -200,6 +200,10 @@ const GatherPage = React.createClass({
 			if (state.from === 'gathering'
 					&& state.to === 'election'
 					&& this.thisGatherer(data.type)) {
+				soundController.stop();
+				this.setState({
+					currentGather: data.type
+				});
 				soundController.playGatherMusic();
 			}
 

--- a/lib/gather/controller.js
+++ b/lib/gather/controller.js
@@ -244,6 +244,15 @@ module.exports = function (namespace) {
 				gather.regather(socket._user, data.regather);
 			}
 
+			if (data.addClassicPool) {
+				let classicGather = GatherPool.get('classic');
+				let playersPool = [];
+				if (classicGather) {
+					playersPool = classicGather.current.gatherers;
+				}
+				gather.voteForAddClassicPool(socket._user, playersPool);
+			}
+
 			refreshGather(data.type);
 		});
 

--- a/lib/gather/gather.js
+++ b/lib/gather/gather.js
@@ -38,6 +38,9 @@ function Gather (options) {
 
 	this.REGATHER_THRESHOLD = this.teamSize + 2;
 
+	// Set the value to 0 to disable AddClassicPool feature
+	this.ADDCLASSICPOOL_THRESHOLD = 2;
+
 	this.type = options.type || "classic";
 
 	this.name = options.name || "Classic Gather";
@@ -74,6 +77,11 @@ StateMachine.create({
 			name: "regather",
 			from: ["gathering", "election", "selection"],
 			to: "gathering"
+		},
+		{ 
+			name: "forceToElection", 
+			from: ["gathering", "election", "selection"], 
+			to: "election"
 		}
 	],
 	callbacks: {
@@ -156,11 +164,30 @@ StateMachine.create({
 		// Remove gatherer event
 		onbeforeremoveGatherer: function (event, from, to, user) {
 			// Cancel transition if no gatherers have been removed
+			const gathererTeam = (this.gatherers
+									  .filter(gatherer => gatherer.id === user.id)[0] || {})
+									  .team;
 			let userCount = this.gatherers.length;
 			this.removeUser(user);
 			let userRemoved = userCount > this.gatherers.length;
 			if (userRemoved && from !== 'gathering') this.applyCooldown(user);
+			if (this.lobbyHasMorePlayersThanNeeded()) {
+				if (from === 'election') return false;
+				if (from === 'selection') {
+					if (gathererTeam === 'lobby') return false;
+					this.forceToElection();
+					return false;
+				}
+			}
 			return userRemoved;
+		},
+
+		onbeforeforceToElection: function (event, from, to) {
+			this.gatherers.forEach(gatherer => {
+				gatherer.leader = false;
+				gatherer.addClassicPoolVote = false;
+				gatherer.team = 'lobby';
+			})
 		},
 
 		// Set gatherer vote & if threshold met, reset gather
@@ -348,7 +375,8 @@ Gather.prototype.toJson = function () {
 		done: {
 			time: this.done.time
 		},
-		cooldown: this.cooldown
+		cooldown: this.cooldown,
+		addClassicPoolThreshold: this.ADDCLASSICPOOL_THRESHOLD
 	}
 };
 
@@ -421,6 +449,42 @@ Gather.prototype.needsToCoolOff = function (user) {
 Gather.prototype.failsTest = function (user) {
 	if (!this.membershipTest) return false;
 	return !this.membershipTest(user);
+};
+
+Gather.prototype.voteForAddClassicPool = function (user, newPlayersPool) {
+	if (!this.ADDCLASSICPOOL_THRESHOLD || this.type !== 'invitational') return;
+	this.modifyGatherer(user, (gatherer) => gatherer.toggleAddClassicPoolVote());
+	if (this.addClassicPoolVotes() >= this.ADDCLASSICPOOL_THRESHOLD && newPlayersPool.length) {
+		this.clearVotesForAddingClassicPool();
+		//Filtering gatherers from a new pool if 
+		//someone has already joined the invitational
+		newPlayersPool = newPlayersPool.filter(newPlayer => {
+			return !this.gatherers.some(presentPlayer => {
+				return presentPlayer.id === newPlayer.id;
+			})
+		});
+		this.gatherers = this.gatherers.concat(newPlayersPool);
+		if (this.lobbyHasMorePlayersThanNeeded()) {
+			this.forceToElection();
+		}
+	}
+};
+
+Gather.prototype.addClassicPoolVotes = function () {
+	return this.gatherers.reduce((acc, gatherer) => {
+		if (gatherer.addClassicPoolVote) acc++;
+		return acc;
+	}, 0);
+};
+
+Gather.prototype.lobbyHasMorePlayersThanNeeded = function() {
+	return this.gatherers.length >= this.teamSize * 2;
+}
+
+Gather.prototype.clearVotesForAddingClassicPool = function() {
+	this.gatherers.forEach(gatherer => {
+		gatherer.addClassicPoolVote = false;
+	});
 }
 
 module.exports = Gather;

--- a/lib/gather/gather.js
+++ b/lib/gather/gather.js
@@ -39,7 +39,7 @@ function Gather (options) {
 	this.REGATHER_THRESHOLD = this.teamSize + 2;
 
 	// Set the value to 0 to disable AddClassicPool feature
-	this.ADDCLASSICPOOL_THRESHOLD = 2;
+	this.ADDCLASSICPOOL_THRESHOLD = 7;
 
 	this.type = options.type || "classic";
 

--- a/lib/gather/gatherer.js
+++ b/lib/gather/gatherer.js
@@ -25,6 +25,7 @@ function Gatherer (user) {
 	this.leader = false;
 	this.team = "lobby"; 
 	this.regatherVote = false;
+	this.addClassicPoolVote = false;
 };
 
 Gatherer.prototype.toggleMapVote = function (mapId) {
@@ -64,6 +65,10 @@ Gatherer.prototype.voteRegather = function (vote) {
 		this.regatherVote = true;
 	}
 	return this.regatherVote;
+};
+
+Gatherer.prototype.toggleAddClassicPoolVote = function () {
+	this.addClassicPoolVote = !this.addClassicPoolVote;
 };
 
 module.exports = Gatherer;

--- a/lib/user/helper.js
+++ b/lib/user/helper.js
@@ -4,8 +4,13 @@ var User = require("../user/user");
 var client = require("../ensl/client")();
 var async = require("async");
 
+//let ids = [6186, 5891, 5890, 2131, 4928, 6301, 3788, 4233];
+
 var getRandomUser = callback => {
 	let id = Math.floor(Math.random() * 5000) + 1;
+ 	/* if (ids.length) {
+		id = ids.pop();
+	}  */ 
 	User.find(id, function (error, user) {
 		if (error) return getRandomUser(callback);
 		return callback(error, user);


### PR DESCRIPTION
Adding a feature so players in the invitational gather can vote by clicking a button (like a regather one) to add a classic gather pool to one big pool. 
Read more: https://www.ensl.org/topics/1838

How to test manually: 
1) uncomment the required lines in "/lib/user/helper.js"
2) RANDOM_USER=true npm run dev
3) first 8 "random" users will be members of invitational group

How to disable feature:
"/lib/gather/gather.js" 
set 'this.ADDCLASSICPOOL_THRESHOLD' to 0

Since I am beginner web-developer I need your codereview ^_^