### PR TITLE
Changed gather kick method to log only the kicked user's id instead of the username

### DIFF
--- a/lib/gather/controller.js
+++ b/lib/gather/controller.js
@@ -165,10 +165,11 @@ module.exports = function (namespace) {
 			if (data.gatherer) {
 				// Remove gatherer defined by ID (admins only)
 				if (!socket._user.isGatherAdmin()) return;
-        removeGatherer(gather, { id: data.gatherer, cooldown: true });
-        let adminName = socket._user.username;
-        let playerName = data.gatherer.user.username;
-        winston.info(`Admin removal: ${adminName} removed ${playerName} from the gather.`);
+				
+				removeGatherer(gather, { id: data.gatherer, cooldown: true });
+				let adminName = socket._user.username;
+				let playerId = data.gatherer;
+				winston.info(`Admin removal: ${adminName} removed ${playerId} from the gather.`);
 			} else {
 				// Remove gatherer attached to socket
 				removeGatherer(gather, socket._user);


### PR DESCRIPTION
So the recent change of adding logging to the kick functionality introduced a bug.
A brief check of the code makes me think its simply an NRE type problem, the **data.gatherer** object doesn't contain the full details of the player being kicked, maybe just the id.
So my change is small, I'm simply logging the kicked players ID instead of their username as I do not have a proper dev environment for this project.

Unfortunately I have not tested this change at all :(