### PR TITLE
Highlight afk gatherers

### DIFF
--- a/app/javascripts/components/gather.js
+++ b/app/javascripts/components/gather.js
@@ -873,14 +873,28 @@ const GathererListItem = React.createClass({
 				</dd>
 			]
 		}
+		
+		const lastSeenInMinutes = (gatherer) => {
+			return parseInt((Date.now() - gatherer.user.lastSeen) / (1000 * 60));
+		};
+
+		let idleStatus;
+		if (!gatherer.user.online) {
+			const mins = lastSeenInMinutes(gatherer);
+			idleStatus = [
+				<dt>Last Seen</dt>,
+				<dd>{mins} mins ago</dd>
+			]
+		}
 
 		let tabColor = gatherer.team !== "lobby" ? `panel-${gatherer.team}` : "panel-info";
+		let onlineStatus = gatherer.user.online ? "" : "font-italic"
 		return (
 			<div className={`panel ${tabColor} gatherer-panel`}
 				key={gatherer.user.id} data-userid={gatherer.user.id}>
 				<div className="panel-heading">
 					<h4 className="panel-title">
-						{country} {gatherer.user.username}
+						{country} <span className={onlineStatus}>{gatherer.user.username}</span> 
 						<span className="pull-right">
 							<a href="#" className="btn btn-xs btn-primary add-right"
 								onClick={this.toggleCollapse}>
@@ -894,6 +908,7 @@ const GathererListItem = React.createClass({
 					className={this.collapseState()} >
 					<div className="panel-body">
 						<dl>
+							{idleStatus}
 							<dt>Skill Level</dt>
 							<dd>{skill}</dd>
 							<dt>Team</dt>

--- a/app/stylesheets/app.css
+++ b/app/stylesheets/app.css
@@ -6,6 +6,10 @@ html, body {
 	margin-top: 1em;
 }
 
+.font-italic {
+	font-style: italic;
+}
+
 /*Chat*/
 
 .wordwrap { 

--- a/lib/gather/controller.js
+++ b/lib/gather/controller.js
@@ -26,15 +26,17 @@ const Event = mongoose.model("Event");
 const _ = require("lodash");
 const winston = require("winston");
 
-const emitGather = (socket, gather) => {
-	socket.emit("gather:refresh", {
-		gather: gather ? gather.toJson() : null,
-		type: gather ? gather.type : null,
-		maps: Map.list,
-	});
-}
-
 module.exports = function (namespace) {
+	const emitGather = (socket, gather) => {
+		const onlineIds = Object.values(namespace.sockets).map(s => s._user.id);
+		
+		socket.emit("gather:refresh", {
+			gather: gather ? gather.toJson(onlineIds) : null,
+			type: gather ? gather.type : null,
+			maps: Map.list,
+		});
+	}
+
 	const refreshArchive = () => {
 		ArchivedGather.recent((error, recentGathers) => {
 			if (error) return winston.error(error);
@@ -78,8 +80,10 @@ module.exports = function (namespace) {
 		gatherManager.onArchiveUpdate(refreshArchive);
 
 		gatherRefreshers[type] = _.debounce(function () {
+			const onlineIds = Object.values(namespace.sockets).map(s => s._user.id);
+
 			namespace.emit("gather:refresh", {
-				gather: gatherManager.current ? gatherManager.current.toJson() : null,
+				gather: gatherManager.current ? gatherManager.current.toJson(onlineIds) : null,
 				type: gatherManager.current ? gatherManager.current.type : null,
 				maps: Map.list,
 			});

--- a/lib/gather/gather.js
+++ b/lib/gather/gather.js
@@ -337,7 +337,18 @@ Gather.prototype.electionStartTime = function () {
 		null : this.election.startTime.toISOString();
 };
 
-Gather.prototype.toJson = function () {
+Gather.prototype.toJson = function (onlineIds) {
+	if (onlineIds) {
+		const now = Date.now();
+		for (var gatherer of this.gatherers) {
+			if (gatherer.user.online) {
+				gatherer.user.lastSeen = now;
+			}
+	
+			gatherer.user.online = onlineIds.indexOf(gatherer.id) !== -1;
+		}
+	}
+
 	return {
 		name: this.name,
 		description: this.description,


### PR DESCRIPTION
Hey guys, here is a branch that shows gather player names in italics and shows how long since they were last seen in the info section.
I just copied the NS1 gather page of making the names italics if they are not on the page.
About the last seen time in the gatherer **info** section. The time it shows is fairly inaccurate, but in the favour of the gatherer. It will never say you have been afk for 6 minutes when you've been only been away 5 minutes, but it will underestimate. It's main purpose is to help admins or mods kick afk people. If they see someone in italics, but afk for 8 minutes, and the gather hasnt filled, you will give the player a while more to come back in the event they are just restarting or something, but if you see a player afk for a few hours, its an easy kick, to prevent the gather starting with the offline player.

Here is how an afk gatherer and an online gatherer (unchanged) look.
Note it only ever displays minutes format
![image](https://user-images.githubusercontent.com/1541024/50940891-a64adb00-147a-11e9-8e41-f65f70d02bbb.png)