### PR TITLE
Fixes a bug where users spamming join and rejoin can sometimes cause …

### DIFF
--- a/lib/gather/controller.js
+++ b/lib/gather/controller.js
@@ -163,6 +163,12 @@ module.exports = function (namespace) {
 
 		const removeGatherer = (gather, user) => {
 			let gatherLeaver = gather.getGatherer(user);
+
+			if (!gatherLeaver) {
+				winston.info(`${user.username} ${user.id} attempted to leave ${gather.type} gather, but was not in gather.`);
+				return;
+			}
+
 			if (gather.can("removeGatherer")) {
 				gather.removeGatherer(user);
 			}


### PR DESCRIPTION
Fixes a bug where users spamming join and rejoin can sometimes cause the UI to request leaving the gather the user is no longer a member of resulting in a crash due to null dereference.

See https://www.ensl.org/bans/879